### PR TITLE
Fix performances in replay mode

### DIFF
--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -107,10 +107,13 @@ void mc_joystick_plugin::before(mc_control::MCGlobalController & controller)
     const auto log = controller.controller().datastore().get<std::shared_ptr<mc_rtc::log::FlatLog>>("Replay::Log");
     if(log->has("joystick_plugin_button_sate"))
     {
-      joystick_button_state_ = log->get<Eigen::VectorXd>("joystick_plugin_button_sate")[t_indx];
-      joystick_button_event_ = log->get<Eigen::VectorXd>("joystick_plugin_button_event")[t_indx];
-      joystick_analogical_state_.col(0) = log->get<Eigen::VectorXd>("joystick_plugin_analogical_state_0")[t_indx];
-      joystick_analogical_state_.col(1) = log->get<Eigen::VectorXd>("joystick_plugin_analogical_state_1")[t_indx];
+      joystick_button_state_ = log->get<Eigen::VectorXd>("joystick_plugin_button_sate", t_indx, joystick_button_state_);
+      joystick_button_event_ =
+          log->get<Eigen::VectorXd>("joystick_plugin_button_event", t_indx, joystick_button_event_);
+      joystick_analogical_state_.col(0) =
+          log->get<Eigen::VectorXd>("joystick_plugin_analogical_state_0", t_indx, Eigen::VectorXd::Zero(0));
+      joystick_analogical_state_.col(1) =
+          log->get<Eigen::VectorXd>("joystick_plugin_analogical_state_1", t_indx, Eigen::VectorXd::Zero(0));
     }
     t_indx += 1;
   }

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -1,6 +1,6 @@
 #include "plugin.h"
-#include <mc_rtc/log/FlatLog.h>
 #include <mc_control/GlobalPluginMacros.h>
+#include <mc_rtc/log/FlatLog.h>
 
 namespace mc_plugin
 {
@@ -39,9 +39,7 @@ void mc_joystick_plugin::init(mc_control::MCGlobalController & controller, const
   joystick_analogical_state_.setZero();
 
   controller.controller().gui()->addElement(
-      {"JoystickPlugin", "State"},
-      mc_rtc::gui::Button(
-          "Reset", [this,&controller]() { reset(controller); }),
+      {"JoystickPlugin", "State"}, mc_rtc::gui::Button("Reset", [this, &controller]() { reset(controller); }),
       mc_rtc::gui::Checkbox(
           "A", [this]() -> bool { return get_inputs(joystickButtonInputs::A) == 1; }, [this]() {}),
       mc_rtc::gui::Checkbox(
@@ -65,19 +63,13 @@ void mc_joystick_plugin::init(mc_control::MCGlobalController & controller, const
           "LB", [this]() -> bool { return get_inputs(joystickButtonInputs::LB) == 1; }, [this]() {}),
       mc_rtc::gui::Checkbox(
           "RB", [this]() -> bool { return get_inputs(joystickButtonInputs::RB) == 1; }, [this]() {}));
-  
-  auto & logger = controller.controller().logger();
-  logger.addLogEntries(this,
-    "joystick_plugin_button_sate",
-    [this]() -> Eigen::VectorXd {return joystick_button_state_;},
-    "joystick_plugin_button_event",
-    [this]() -> Eigen::VectorXd {return joystick_button_event_;},
-    "joystick_plugin_analogical_state_0",
-    [this]() -> Eigen::VectorXd {return joystick_analogical_state_.col(0);},
-    "joystick_plugin_analogical_state_1",
-    [this]() -> Eigen::VectorXd {return joystick_analogical_state_.col(1);}
-    );
 
+  auto & logger = controller.controller().logger();
+  logger.addLogEntries(
+      this, "joystick_plugin_button_sate", [this]() -> Eigen::VectorXd { return joystick_button_state_; },
+      "joystick_plugin_button_event", [this]() -> Eigen::VectorXd { return joystick_button_event_; },
+      "joystick_plugin_analogical_state_0", [this]() -> Eigen::VectorXd { return joystick_analogical_state_.col(0); },
+      "joystick_plugin_analogical_state_1", [this]() -> Eigen::VectorXd { return joystick_analogical_state_.col(1); });
 }
 
 double mc_joystick_plugin::get_inputs(joystickButtonInputs in)
@@ -112,15 +104,15 @@ void mc_joystick_plugin::before(mc_control::MCGlobalController & controller)
   controller.controller().datastore().assign<bool>("Joystick::connected", joystickConnected_);
   if(controller.controller().datastore().has("Replay::Log"))
   {
-    const auto log = controller.controller().datastore().get< std::shared_ptr<mc_rtc::log::FlatLog> >("Replay::Log");
+    const auto log = controller.controller().datastore().get<std::shared_ptr<mc_rtc::log::FlatLog>>("Replay::Log");
     if(log->has("joystick_plugin_button_sate"))
     {
-      joystick_button_state_ = log->get< Eigen::VectorXd >("joystick_plugin_button_sate")[t_indx];
-      joystick_button_event_ = log->get< Eigen::VectorXd >("joystick_plugin_button_event")[t_indx];
-      joystick_analogical_state_.col(0) = log->get< Eigen::VectorXd >("joystick_plugin_analogical_state_0")[t_indx];
-      joystick_analogical_state_.col(1) = log->get< Eigen::VectorXd >("joystick_plugin_analogical_state_1")[t_indx];
+      joystick_button_state_ = log->get<Eigen::VectorXd>("joystick_plugin_button_sate")[t_indx];
+      joystick_button_event_ = log->get<Eigen::VectorXd>("joystick_plugin_button_event")[t_indx];
+      joystick_analogical_state_.col(0) = log->get<Eigen::VectorXd>("joystick_plugin_analogical_state_0")[t_indx];
+      joystick_analogical_state_.col(1) = log->get<Eigen::VectorXd>("joystick_plugin_analogical_state_1")[t_indx];
     }
-    t_indx +=1;
+    t_indx += 1;
   }
   else if(joystickConnected_)
   {

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -46,7 +46,7 @@ private:
   double leftTrigger_range_ = 1;
   double rightTrigger_range_ = 1;
 
-  int t_indx = 0; // elapsed iteration;
+  size_t t_indx = 0; // elapsed iteration;
 };
 
 } // namespace mc_plugin

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -46,7 +46,7 @@ private:
   double leftTrigger_range_ = 1;
   double rightTrigger_range_ = 1;
 
-  int t_indx = 0; //elapsed iteration;  
+  int t_indx = 0; // elapsed iteration;
 };
 
 } // namespace mc_plugin


### PR DESCRIPTION
This PR fixes performance issues when using this plugin in a replay.

The issue comes from the usage of the FlatLog API that returns the full data vector instead of requesting the value at a given iteration.

Before this patch, the replay on e.g. ismpc_walking controller was 0.2 real-time ratio (I assume it would get worse the bigger the log gets) and it is 5.5  after the fix.