### PR TITLE
Fix init/reset mixup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,12 +29,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04]
         build-type: [RelWithDebInfo]
         compiler: [gcc]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: Install dependencies

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -7,16 +7,34 @@ namespace mc_plugin
 
 mc_joystick_plugin::~mc_joystick_plugin() = default;
 
-void mc_joystick_plugin::init(mc_control::MCGlobalController & controller, const mc_rtc::Configuration & config)
+void mc_joystick_plugin::init(mc_control::MCGlobalController & controller, const mc_rtc::Configuration &)
 {
-  if(controller.controller().config().has("JoystickPlugin"))
-  {
-    configure(controller.controller().config()("JoystickPlugin"));
-  }
-  else
-  {
-    configure(config);
-  }
+  reset(controller);
+}
+
+double mc_joystick_plugin::get_inputs(joystickButtonInputs in)
+{
+  return joystick_button_state_(in);
+}
+double mc_joystick_plugin::get_events(joystickButtonInputs in)
+{
+  return joystick_button_event_(in);
+}
+double mc_joystick_plugin::get_inputs(joystickAnalogicInputs in)
+{
+
+  return joystick_analogical_state_(in, 0);
+}
+Eigen::Vector2d mc_joystick_plugin::get_stick_value(joystickAnalogicInputs in)
+{
+  return Eigen::Vector2d{joystick_analogical_state_(in, 0), joystick_analogical_state_(in, 1)};
+}
+
+void mc_joystick_plugin::reset(mc_control::MCGlobalController & controller)
+{
+  mc_rtc::log::info("mc_joystick_plugin::reset called");
+  joystickConnected_ = false;
+  joystick_.reset();
   if(!joystick_.isFound())
   {
     joystickConnected_ = false;
@@ -70,31 +88,6 @@ void mc_joystick_plugin::init(mc_control::MCGlobalController & controller, const
       "joystick_plugin_button_event", [this]() -> Eigen::VectorXd { return joystick_button_event_; },
       "joystick_plugin_analogical_state_0", [this]() -> Eigen::VectorXd { return joystick_analogical_state_.col(0); },
       "joystick_plugin_analogical_state_1", [this]() -> Eigen::VectorXd { return joystick_analogical_state_.col(1); });
-}
-
-double mc_joystick_plugin::get_inputs(joystickButtonInputs in)
-{
-  return joystick_button_state_(in);
-}
-double mc_joystick_plugin::get_events(joystickButtonInputs in)
-{
-  return joystick_button_event_(in);
-}
-double mc_joystick_plugin::get_inputs(joystickAnalogicInputs in)
-{
-
-  return joystick_analogical_state_(in, 0);
-}
-Eigen::Vector2d mc_joystick_plugin::get_stick_value(joystickAnalogicInputs in)
-{
-  return Eigen::Vector2d{joystick_analogical_state_(in, 0), joystick_analogical_state_(in, 1)};
-}
-
-void mc_joystick_plugin::reset(mc_control::MCGlobalController & controller)
-{
-  mc_rtc::log::info("mc_joystick_plugin::reset called");
-  joystickConnected_ = false;
-  joystick_.reset();
 }
 
 void mc_joystick_plugin::before(mc_control::MCGlobalController & controller)

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -25,11 +25,6 @@ struct mc_joystick_plugin : public mc_control::GlobalPlugin
 
   ~mc_joystick_plugin() override;
 
-  void configure(const mc_rtc::Configuration & config)
-  {
-    mc_rtc::log::info("[mc_joystick_plugin] configuration:\n{}", config.dump(true, true));
-  }
-
   double get_inputs(joystickButtonInputs input);
   double get_inputs(joystickAnalogicInputs input);
   double get_events(joystickButtonInputs in);


### PR DESCRIPTION
This fixes issues that arise when:
- multiple controllers that use the plugin are chained
- `MCGlobalController` is reset